### PR TITLE
Fix: duplicated node causes changeset being rejected

### DIFF
--- a/common.py
+++ b/common.py
@@ -62,7 +62,7 @@ def obj_to_dict(obj):
         return None
     res = {}
     res['type'] = obj.tag
-    res['id'] = int(obj.get('id'))
+    res['id'] = obj.get('id')
     res['version'] = int(obj.get('version'))
     res['deleted'] = obj.get('visible') == 'false'
     if obj.tag == 'node' and 'lon' in obj.keys() and 'lat' in obj.keys():


### PR DESCRIPTION
Duplicated node wasn't filtered out because id in `qobj` is integer while which in `processed` is string. It caused changeset being rejected by OSM API server.

https://github.com/Zverik/simple-revert/blob/eb359a50e8ec504d6f806fcf5dbac79be1391169/restore_version.py#L149

https://github.com/Zverik/simple-revert/blob/eb359a50e8ec504d6f806fcf5dbac79be1391169/restore_version.py#L170