### PR TITLE
restore_version: Restore multiple objects in a single run's changeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Here are two Python scripts that:
 * Revert simple OpenStreetMap changesets.
 Way and relation structural changes cannot be reverted, all other changes can.
 For example, if you deleted a lot of objects, or changed many tags at once.
-* Restore an old version of a given object. All of its deleted references
+* Restore an old version of given object(s). All of their deleted references
 are restored as well.
 
 If there are no errors, scripts would ask you for OSM login and password (which
@@ -43,6 +43,11 @@ to the last version. E.g. this command will revert the last change to a node:
     restore_version n12345 -1
 
 To get a list of recent versions, run the script without a version argument.
+
+You can pass several objects to restore them all in one changeset:
+
+    restore_version n12345 -1 w1234 -1 w1235 -1
+
 
 ## Author and License
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = simple_revert
-version = 1.0.0
+version = 1.1.0
 author = Ilya Zverev
 author_email = ilya@zverev.info
 description = CLI tool and library to revert changes in OpenStreetMap

--- a/simple_revert/restore_version.py
+++ b/simple_revert/restore_version.py
@@ -66,7 +66,10 @@ def safe_print(s):
 
 
 def get_obj_history(obj_type, obj_id, obj_version):
-    """Download object history; params are from tuple returned by parse_url. If obj_version None, prints history and exits. Otherwise returns object's history list."""
+    """ Download object history; params are from tuple returned by parse_url.
+    If obj_version None, prints history and exits.
+    Returns object's history list.
+    """
     # Download full object history
     # If we fail, revert to a given version blindly
     history = None
@@ -101,7 +104,9 @@ def get_obj_history(obj_type, obj_id, obj_version):
 
 
 def get_obj_version(obj_type, obj_id, obj_version, obj_history):
-    """Get requested object version, or exit(1). Updates obj_version if negative. Returns tuple (obj_version, last_version, vref)"""
+    """ Get requested object version, or exit(1). Updates obj_version if negative.
+    Returns tuple (obj_version, last_version, vref).
+    """
     last_version = int(obj_history[-1].get('version'))
     if obj_version < 0:
         obj_version = last_version + obj_version
@@ -135,7 +140,10 @@ def get_obj_version(obj_type, obj_id, obj_version, obj_history):
 
 
 def build_undelete_changes(restore_objs):
-    """For each (obj_type, obj_id, obj_version, obj_history) item in restore_objs, traverse its obj_history to build changeset to undelete it. Returns tuple (changes or [], comment)"""
+    """ For each (obj_type, obj_id, obj_version, obj_history) item in restore_objs,
+    traverse its obj_history to build changeset to undelete it.
+    Returns tuple (changes or [], comment).
+    """
     comment = ""
     changes = []
     queue = deque()
@@ -143,7 +151,8 @@ def build_undelete_changes(restore_objs):
     for obj_item in restore_objs:
         obj_type, obj_id, obj_version, obj_history = obj_item[0:4]
 
-        obj_version, last_version, vref = get_obj_version(obj_type, obj_id, obj_version, obj_history)
+        obj_version, last_version, vref = get_obj_version(
+            obj_type, obj_id, obj_version, obj_history)
 
         # Now building a list of changes, traversing all references, finding objects to undelete
         obj = obj_to_dict(vref)
@@ -198,9 +207,10 @@ def build_undelete_changes(restore_objs):
 
 
 def print_usage_and_exit():
-    print('Restores a specific version of each given object, undeleting all missing references')
+    print('Restores a specific version of given objects, undeleting all missing references')
     print()
-    print('Usage: {0} {{<typeNNN>|<url>}} [{{<version>|-N}}] [{{<typeNNN> <version>|-N}} | {{<url>}}] ...'.format(sys.argv[0]))
+    print('Usage: {0} {{<typeNNN>|<url>}} [{{<version>|-N}}] ' +
+          '[{{<typeNNN> <version>|-N}} | {{<url>}}] ...'.format(sys.argv[0]))
     print()
     print('URLs both from osm.org and api.osm.org (even with version) are accepted.')
     print('Use -1 to revert last version (e.g. undelete an object).')
@@ -230,7 +240,8 @@ def main():
                 try:
                     obj_version = int(sys.argv[i])
                 except ValueError:
-                    safe_print('Expected version number after {0}, got {1}'.format(sys.argv[i-1], sys.argv[i]))
+                    safe_print('Expected version number after {0}, got {1}'.format(
+                        sys.argv[i-1], sys.argv[i]))
                 i += 1
             if obj_version is None:
                 print_usage_and_exit()


### PR DESCRIPTION
Hi, thanks for writing and maintaining this very useful set of scripts!

I've added a feature to `restore_version.py` to restore multiple objects in a single changeset. Tested with a few ways and nodes (with a few nodes shared among those ways).

I updated the readme with example usage:
```
restore_version n12345 -1 w1234 -1 w1235 -1
```

it also accepts a mix of that pair-of-arguments format and the url-based `/node/12345/7` formats.

Thanks again,
-Jeremy